### PR TITLE
Hotfix/histogram duplicates or absent

### DIFF
--- a/mealy/error_analysis_utils.py
+++ b/mealy/error_analysis_utils.py
@@ -47,6 +47,4 @@ def check_enough_data(df, min_len):
 
 def rank_features_by_error_correlation(feature_importances):
     sorted_feature_indices = np.argsort(- feature_importances)
-    cut = len(np.where(feature_importances != 0)[0])
-    sorted_feature_indices = sorted_feature_indices[:cut]
     return sorted_feature_indices

--- a/mealy/error_analysis_utils.py
+++ b/mealy/error_analysis_utils.py
@@ -46,5 +46,4 @@ def check_enough_data(df, min_len):
 
 
 def rank_features_by_error_correlation(feature_importances):
-    sorted_feature_indices = np.argsort(- feature_importances)
-    return sorted_feature_indices
+    return np.argsort(- feature_importances)

--- a/mealy/error_visualizer.py
+++ b/mealy/error_visualizer.py
@@ -221,8 +221,8 @@ class ErrorVisualizer(_BaseErrorVisualizer):
             min_values, max_values = x.min(axis=0), x.max(axis=0)
             feature_names = self.mpp_feature_names
         else:
-            ranked_feature_ids = [self.pipeline_preprocessor.inverse_transform_feature_id(idx) for idx in
-                                  ranked_feature_ids]
+            ranked_feature_ids = list(set([self.pipeline_preprocessor.inverse_transform_feature_id(idx) for idx in
+                                  ranked_feature_ids]))
             if top_k_features > 0:
                 ranked_feature_ids = ranked_feature_ids[:top_k_features]
             x, y = self.pipeline_preprocessor.inverse_transform(self._error_train_x)[:,

--- a/mealy/error_visualizer.py
+++ b/mealy/error_visualizer.py
@@ -221,8 +221,8 @@ class ErrorVisualizer(_BaseErrorVisualizer):
             min_values, max_values = x.min(axis=0), x.max(axis=0)
             feature_names = self.mpp_feature_names
         else:
-            ranked_feature_ids = list(set([self.pipeline_preprocessor.inverse_transform_feature_id(idx) for idx in
-                                  ranked_feature_ids]))
+            ranked_feature_ids = list(set(self.pipeline_preprocessor.inverse_transform_feature_id(idx) for idx in
+                                          ranked_feature_ids))
             if top_k_features > 0:
                 ranked_feature_ids = ranked_feature_ids[:top_k_features]
             x, y = self.pipeline_preprocessor.inverse_transform(self._error_train_x)[:,


### PR DESCRIPTION
- when user selected `top_k_features` to display all feature distributions, some of them were not shown as they have 0 importance for the decision tree, but the user needs to be able to look at the distribution of all features in a node
- when using pipeline, some features hist were duplicated (multiple hist for the one hot encoded features)