### PR TITLE
Hotfix/tree viz

### DIFF
--- a/mealy/constants.py
+++ b/mealy/constants.py
@@ -38,3 +38,6 @@ class ErrorAnalyzerConstants(object):
     STEPS_THAT_CHANGE_OUTPUT_DIMENSION_WITH_OUTPUT_FEATURE_NAMES = (OneHotEncoder,)
     # for imputers we don't need inverse function
     STEPS_THAT_CAN_BE_INVERSED_WITH_IDENTICAL_FUNCTION = (SimpleImputer, KNNImputer)
+
+    GRAPH_MAX_EDGE_WIDTH = 10
+    GRAPH_MIN_LOCAL_ERROR_OPAQUE = 0.5

--- a/mealy/error_tree.py
+++ b/mealy/error_tree.py
@@ -15,6 +15,7 @@ class ErrorTree(object):
         self._impurity = None
         self._quantized_impurity = None
         self._difference = None
+        self._global_error = None
 
         self._check_error_tree()
 
@@ -41,6 +42,12 @@ class ErrorTree(object):
         if self._difference is None:
             self._compute_ranking_arrays()
         return self._difference
+
+    @property
+    def global_error(self):
+        if self._global_error is None:
+            self._compute_ranking_arrays()
+        return self._global_error
 
     @property
     def leaf_ids(self):
@@ -74,3 +81,7 @@ class ErrorTree(object):
         purity_bins = np.linspace(0, 1., n_purity_levels)
         self._quantized_impurity = np.digitize(self._impurity, purity_bins)
         self._difference = correctly_predicted_samples - wrongly_predicted_samples  # only negative numbers
+
+        #y = self._error_train_y
+        n_total_errors = np.sum(wrongly_predicted_samples) #y[y == ErrorAnalyzerConstants.WRONG_PREDICTION].shape[0]
+        self._global_error = wrongly_predicted_samples.astype(float) / n_total_errors

--- a/mealy/error_visualizer.py
+++ b/mealy/error_visualizer.py
@@ -198,7 +198,7 @@ class ErrorVisualizer(_BaseErrorVisualizer):
 
                 if not (parent_id is None):
                     parent_edge = pydot_graph.get_edge(str(parent_id), node.get_name())[0]
-                    parent_edge.set_penwidth(ErrorAnalyzerConstants.GRAPH_MAX_EDGE_WIDTH * global_error)
+                    parent_edge.set_penwidth(max(1, ErrorAnalyzerConstants.GRAPH_MAX_EDGE_WIDTH * global_error))
                     parent_edge.set_label('%.3f %%' % (global_error * 100))
 
         if size is not None:

--- a/mealy/error_visualizer.py
+++ b/mealy/error_visualizer.py
@@ -142,8 +142,8 @@ class ErrorVisualizer(_BaseErrorVisualizer):
             if node.get_label():
                 node_label = node.get_label().strip('"')
                 new_label = node_label
+                idx = int(node_label.split('node #')[1].split('\\n')[0])
                 if ' <= ' in node_label:
-                    idx = int(node_label.split('node #')[1].split('\\n')[0])
                     lte_split = node_label.split(' <= ')
                     entropy_split = lte_split[1].split('\\nentropy')
 
@@ -166,28 +166,20 @@ class ErrorVisualizer(_BaseErrorVisualizer):
                 node.set_label(new_label)
 
                 alpha = 0.0
-                entropy = 0.0
-                node_class = ErrorAnalyzerConstants.CORRECT_PREDICTION
+                global_error = 0.0
                 if 'value = [' in node_label:
-                    values = [float(ii) for ii in node_label.split('value = [')[1].split(']')[0].split(',')]
-                    node_arg_class = np.argmax(values)
-                    node_class = self._error_clf.classes_[node_arg_class]
                     # transparency as the global error
-                    idx = int(node_label.split('node #')[1].split('\\n')[0])
                     global_error = float(wrongly_predicted_samples[idx]) / n_total_errors
-                    alpha = 0.5 + 0.5 * global_error  # scale in [0.5, 1]
-                    entropy = 1 - values[node_arg_class]
+                    alpha = min(1., 2 * global_error)  # scale in [0.5, 1]
 
+                node_class = ErrorAnalyzerConstants.CORRECT_PREDICTION if global_error == 0 \
+                    else ErrorAnalyzerConstants.WRONG_PREDICTION
                 class_color = ErrorAnalyzerConstants.ERROR_TREE_COLORS[node_class].strip('#')
                 class_color_rgb = tuple(int(class_color[i:i + 2], 16) for i in (0, 2, 4))
                 # compute the color as alpha against white
                 color_rgb = [int(round(alpha * c + (1 - alpha) * 255, 0)) for c in class_color_rgb]
                 color = '#{:02x}{:02x}{:02x}'.format(color_rgb[0], color_rgb[1], color_rgb[2])
                 node.set_fillcolor(color)
-                if node_class == ErrorAnalyzerConstants.CORRECT_PREDICTION and entropy > 0.:
-                    class_color = ErrorAnalyzerConstants.ERROR_TREE_COLORS[ErrorAnalyzerConstants.WRONG_PREDICTION]
-                    node.set_color(class_color)
-                    node.set_penwidth(3)
 
         if size is not None:
             pydot_graph.set_size('"%d,%d!"' % (size[0], size[1]))

--- a/mealy/error_visualizer.py
+++ b/mealy/error_visualizer.py
@@ -129,6 +129,12 @@ class ErrorVisualizer(_BaseErrorVisualizer):
         thresholds = self.thresholds
         features = self.features
 
+        y = self._error_train_y
+        n_total_errors = y[y == ErrorAnalyzerConstants.WRONG_PREDICTION].shape[0]
+        error_class_idx = \
+            np.where(self._error_clf.classes_ == ErrorAnalyzerConstants.WRONG_PREDICTION)[0][0]
+        wrongly_predicted_samples = self._error_clf.tree_.value[:, 0, error_class_idx]
+
         nodes = pydot_graph.get_node_list()
         for node in nodes:
             if node.get_label():
@@ -150,24 +156,36 @@ class ErrorVisualizer(_BaseErrorVisualizer):
                         lte_split_without_feature = lte_split[0].split('\\n')[0]
                         lte_split_with_new_feature = lte_split_without_feature + '\\n' + split_feature
                         lte_modified = ' != '.join([lte_split_with_new_feature, str(descaled_value)])
-                    new_label = '\\nentropy'.join([lte_modified, entropy_split[1]])
+                    new_label = '\\nentropy'.join([lte_modified, entropy_split[1]]).strip('"')
+
+                    global_error = float(wrongly_predicted_samples[idx]) / n_total_errors
+                    new_label += '\\nglobal error = %.3f %%\\n' % (global_error * 100)
 
                     node.set_label(new_label)
 
                 alpha = 0.0
+                entropy = 0.0
                 node_class = ErrorAnalyzerConstants.CORRECT_PREDICTION
                 if 'value = [' in node_label:
                     values = [float(ii) for ii in node_label.split('value = [')[1].split(']')[0].split(',')]
                     node_arg_class = np.argmax(values)
                     node_class = self._error_clf.classes_[node_arg_class]
-                    # transparency as the entropy value
-                    alpha = values[node_arg_class]
+                    # transparency as the global error
+                    idx = int(node_label.split('node #')[1].split('\\n')[0])
+                    global_error = float(wrongly_predicted_samples[idx]) / n_total_errors
+                    alpha = 0.5 + 0.5 * global_error  # scale in [0.5, 1]
+                    entropy = 1 - values[node_arg_class]
+
                 class_color = ErrorAnalyzerConstants.ERROR_TREE_COLORS[node_class].strip('#')
                 class_color_rgb = tuple(int(class_color[i:i + 2], 16) for i in (0, 2, 4))
                 # compute the color as alpha against white
                 color_rgb = [int(round(alpha * c + (1 - alpha) * 255, 0)) for c in class_color_rgb]
                 color = '#{:02x}{:02x}{:02x}'.format(color_rgb[0], color_rgb[1], color_rgb[2])
                 node.set_fillcolor(color)
+                if node_class == ErrorAnalyzerConstants.CORRECT_PREDICTION and entropy > 0.:
+                    class_color = ErrorAnalyzerConstants.ERROR_TREE_COLORS[ErrorAnalyzerConstants.WRONG_PREDICTION]
+                    node.set_color(class_color)
+                    node.set_penwidth(3)
 
         if size is not None:
             pydot_graph.set_size('"%d,%d!"' % (size[0], size[1]))

--- a/mealy/error_visualizer.py
+++ b/mealy/error_visualizer.py
@@ -175,10 +175,10 @@ class ErrorVisualizer(_BaseErrorVisualizer):
 
         return gvz_graph
 
-    def plot_feature_distributions_on_leaves(self, leaf_selector='all_errors',
+    def plot_feature_distributions_on_leaves(self, leaf_selector='all',
                                              top_k_features=ErrorAnalyzerConstants.TOP_K_FEATURES,
-                                             show_global=True, show_class=False, rank_leaves_by="purity", nr_bins=10,
-                                             figsize=(15, 10)):
+                                             show_global=True, show_class=True, rank_leaves_by="global_error",
+                                             nr_bins=10, figsize=(15, 10)):
         """Return plot of error node feature distribution and compare to global baseline.
 
         The top-k features are sorted by importance in the Model Performance Predictor.
@@ -188,8 +188,8 @@ class ErrorVisualizer(_BaseErrorVisualizer):
         Args:
 
             leaf_selector (int or list or str): the desired leaf nodes to visualize. When int it represents the
-                number of the leaf node, when a list it represents a list of leaf nodes. When a string, the valid values
-                are either 'all_error' to plot all leaves of class 'Wrong prediction' or 'all' to plot all leaf nodes.
+                number of the leaf node, when a list it represents a list of leaf nodes. When a string, the valid value
+                is 'all' to plot all leaf nodes.
 
             top_k_features (int): number of features to plot per node.
 
@@ -199,9 +199,10 @@ class ErrorVisualizer(_BaseErrorVisualizer):
             show_class (bool): show the proportion of Wrongly and Correctly predicted samples in the feature
                 distributions.
 
-            rank_leaves_by (str): ranking criterium for the leaf nodes. It can be either 'purity' to rank by the leaf
-                node purity (ratio of wrongly predicted samples over the total for an error node) or 'class_difference'
-                (difference of number of wrongly and correctly predicted samples in a node).
+            rank_leaves_by (str): ranking criterion for the leaf nodes. It can be 'global_error' to rank by the global
+                error (percentage of total error in the node), 'purity' to rank by the leaf node purity (ratio of
+                wrongly predicted samples over the total for an error node) or 'class_difference' (difference of number
+                of wrongly and correctly predicted samples in a node).
 
             nr_bins (int): number of bins in the feature distribution plots.
 

--- a/mealy/error_visualizer.py
+++ b/mealy/error_visualizer.py
@@ -9,13 +9,14 @@ from mealy.constants import ErrorAnalyzerConstants
 from mealy.error_analyzer import ErrorAnalyzer
 
 import logging
+
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format='mealy | %(levelname)s - %(message)s')
 
 plt.rc('font', family="sans-serif")
 SMALL_SIZE, MEDIUM_SIZE, BIGGER_SIZE = 8, 10, 12
 plt.rc('axes', titlesize=BIGGER_SIZE, labelsize=MEDIUM_SIZE)
-plt.rc('xtick', labelsize=SMALL_SIZE) 
+plt.rc('xtick', labelsize=SMALL_SIZE)
 plt.rc('ytick', labelsize=SMALL_SIZE)
 plt.rc('legend', fontsize=SMALL_SIZE)
 plt.rc("hatch", color="white", linewidth=4)
@@ -27,7 +28,8 @@ class _BaseErrorVisualizer(object):
             raise NotImplementedError('You need to input an ErrorAnalyzer object.')
 
         self._error_analyzer = error_analyzer
-        self.get_ranked_leaf_ids = lambda leaf_selector, rank_by: error_analyzer.get_ranked_leaf_ids(leaf_selector, rank_by)
+        self.get_ranked_leaf_ids = lambda leaf_selector, rank_by: error_analyzer.get_ranked_leaf_ids(leaf_selector,
+                                                                                                     rank_by)
 
     @staticmethod
     def _plot_histograms(hist_data, label, **params):
@@ -138,8 +140,8 @@ class ErrorVisualizer(_BaseErrorVisualizer):
         nodes = pydot_graph.get_node_list()
         for node in nodes:
             if node.get_label():
-                node_label = node.get_label()
-
+                node_label = node.get_label().strip('"')
+                new_label = node_label
                 if ' <= ' in node_label:
                     idx = int(node_label.split('node #')[1].split('\\n')[0])
                     lte_split = node_label.split(' <= ')
@@ -156,12 +158,12 @@ class ErrorVisualizer(_BaseErrorVisualizer):
                         lte_split_without_feature = lte_split[0].split('\\n')[0]
                         lte_split_with_new_feature = lte_split_without_feature + '\\n' + split_feature
                         lte_modified = ' != '.join([lte_split_with_new_feature, str(descaled_value)])
-                    new_label = '\\nentropy'.join([lte_modified, entropy_split[1]]).strip('"')
+                    new_label = '\\nentropy'.join([lte_modified, entropy_split[1]])
 
-                    global_error = float(wrongly_predicted_samples[idx]) / n_total_errors
-                    new_label += '\\nglobal error = %.3f %%\\n' % (global_error * 100)
+                global_error = float(wrongly_predicted_samples[idx]) / n_total_errors
+                new_label += '\\nglobal error = %.3f %%\\n' % (global_error * 100)
 
-                    node.set_label(new_label)
+                node.set_label(new_label)
 
                 alpha = 0.0
                 entropy = 0.0
@@ -276,7 +278,7 @@ class ErrorVisualizer(_BaseErrorVisualizer):
                         histogram_func = lambda f_samples: np.histogram(f_samples, bins=bins, density=False)[0]
                     else:
                         histogram_func = lambda f_samples: np.histogram(f_samples, bins=bins, density=True)[0]
-                        
+
                 else:
 
                     bins = np.unique(feature_column)[:nr_bins]

--- a/mealy/error_visualizer.py
+++ b/mealy/error_visualizer.py
@@ -187,7 +187,6 @@ class ErrorVisualizer(_BaseErrorVisualizer):
                 if not (parent_id is None):
                     parent_edge = pydot_graph.get_edge(str(parent_id), node.get_name())[0]
                     parent_edge.set_penwidth(max(1, ErrorAnalyzerConstants.GRAPH_MAX_EDGE_WIDTH * global_error))
-                    parent_edge.set_label('%.3f %%' % (global_error * 100))
 
         if size is not None:
             pydot_graph.set_size('"%d,%d!"' % (size[0], size[1]))

--- a/mealy/error_visualizer.py
+++ b/mealy/error_visualizer.py
@@ -121,14 +121,12 @@ class ErrorVisualizer(_BaseErrorVisualizer):
         thresholds = self._thresholds
         features = self._features
 
-        y = self._error_train_y
+        y = self._error_analyzer._error_train_y
         n_total_errors = y[y == ErrorAnalyzerConstants.WRONG_PREDICTION].shape[0]
-        error_class_idx = \
-            np.where(self._error_clf.classes_ == ErrorAnalyzerConstants.WRONG_PREDICTION)[0][0]
+        error_class_idx = np.where(self._error_clf.classes_ == ErrorAnalyzerConstants.WRONG_PREDICTION)[0][0]
         wrongly_predicted_samples = self._error_clf.tree_.value[:, 0, error_class_idx]
 
-        correct_class_idx = \
-            np.where(self._error_clf.classes_ == ErrorAnalyzerConstants.CORRECT_PREDICTION)[0][0]
+        correct_class_idx = np.where(self._error_clf.classes_ == ErrorAnalyzerConstants.CORRECT_PREDICTION)[0][0]
         well_predicted_samples = self._error_clf.tree_.value[:, 0, correct_class_idx]
 
         nodes = pydot_graph.get_node_list()

--- a/mealy/tests/test_error_analyzer.py
+++ b/mealy/tests/test_error_analyzer.py
@@ -31,7 +31,7 @@ def test_with_only_scikit_model():
     mpp = ErrorAnalyzer(rf, feature_names=numeric_features, param_grid={'max_depth': [5, 10, None], 'min_samples_leaf': [10, 20]})
     mpp.fit(X_test, y_test)
 
-    prep_x, y_true = mpp._compute_primary_model_error(X_test.values, y_test)
+    prep_x, y_true, _ = mpp._compute_primary_model_error(X_test.values, y_test)
     y_pred = mpp._error_tree.estimator_.predict(prep_x)
 
     mpp_accuracy_score = compute_mpp_accuracy(y_true, y_pred)
@@ -91,7 +91,7 @@ def test_with_scikit_pipeline():
 
     X_test_prep, y_test_prep = mpp.pipeline_preprocessor.transform(X_test), np.array(y_test)
 
-    prep_x, y_true = mpp._compute_primary_model_error(X_test_prep, y_test_prep)
+    prep_x, y_true, _ = mpp._compute_primary_model_error(X_test_prep, y_test_prep)
     y_pred = mpp._error_tree.estimator_.predict(prep_x)
 
     mpp_accuracy_score = compute_mpp_accuracy(y_true, y_pred)


### PR DESCRIPTION
- add global error in node (text)
- use local error to color the nodes (higher local error -> more opaque)
- edge penwidth as the global error

![Screenshot 2021-02-22 at 15 06 21](https://user-images.githubusercontent.com/13200110/108719266-a5247d00-751f-11eb-8a2c-a13334a5495b.png)

