### PR TITLE
change nodes label in the tree viz to include local error + simplify

### DIFF
--- a/mealy/error_visualizer.py
+++ b/mealy/error_visualizer.py
@@ -159,10 +159,8 @@ class ErrorVisualizer(_BaseErrorVisualizer):
                     new_label = samples_split[0]
 
                 value_split = samples_split[1].split('\\nvalue')
-                class_split = value_split[1].split('\\nclass')
 
                 new_label += '\\nsamples' + value_split[0] + \
-                             '\\nclass' + class_split[1] + \
                              '\\nlocal error = %.3f %%' % (local_error * 100) + \
                              '\\nglobal error = %.3f %%\\n' % (global_error * 100)
 

--- a/mealy/error_visualizer.py
+++ b/mealy/error_visualizer.py
@@ -113,7 +113,8 @@ class ErrorVisualizer(_BaseErrorVisualizer):
                                        rotate=False,
                                        out_file=None,
                                        filled=True,
-                                       rounded=True)
+                                       rounded=True,
+                                       impurity=False)
 
         pydot_graph = pydotplus.graph_from_dot_data(str(digraph_tree))
 
@@ -134,14 +135,15 @@ class ErrorVisualizer(_BaseErrorVisualizer):
         for node in nodes:
             if node.get_label():
                 node_label = node.get_label().strip('"')
-                new_label = node_label
                 idx = int(node_label.split('node #')[1].split('\\n')[0])
+                global_error = float(wrongly_predicted_samples[idx]) / n_total_errors
+                local_error = float(wrongly_predicted_samples[idx]) / (
+                            well_predicted_samples[idx] + wrongly_predicted_samples[idx])
                 if ' <= ' in node_label:
                     lte_split = node_label.split(' <= ')
-                    entropy_split = lte_split[1].split('\\nentropy')
+                    samples_split = lte_split[1].split('\\nsamples')
 
                     split_feature = self._original_feature_names[features[idx]]
-
                     descaled_value = thresholds[idx]
 
                     if split_feature in self._numerical_feature_names:
@@ -151,12 +153,18 @@ class ErrorVisualizer(_BaseErrorVisualizer):
                         lte_split_without_feature = lte_split[0].split('\\n')[0]
                         lte_split_with_new_feature = lte_split_without_feature + '\\n' + split_feature
                         lte_modified = ' != '.join([lte_split_with_new_feature, str(descaled_value)])
-                    new_label = '\\nentropy'.join([lte_modified, entropy_split[1]])
+                    new_label = lte_modified
+                else:
+                    samples_split = node_label.split('\\nsamples')
+                    new_label = samples_split[0]
 
-                global_error = float(wrongly_predicted_samples[idx]) / n_total_errors
-                local_error = float(wrongly_predicted_samples[idx]) / (
-                            well_predicted_samples[idx] + wrongly_predicted_samples[idx])
-                new_label += '\\nglobal error = %.3f %%\\n' % (global_error * 100)
+                value_split = samples_split[1].split('\\nvalue')
+                class_split = value_split[1].split('\\nclass')
+
+                new_label += '\\nsamples' + value_split[0] + \
+                             '\\nclass' + class_split[1] + \
+                             '\\nlocal error = %.3f %%' % (local_error * 100) + \
+                             '\\nglobal error = %.3f %%\\n' % (global_error * 100)
 
                 node.set_label(new_label)
 


### PR DESCRIPTION
In the visualization of the tree the nodes have simpler labels containing local and global error key metrics.

<img width="254" alt="Screenshot 2021-02-22 at 22 23 17" src="https://user-images.githubusercontent.com/13200110/108772011-be97ea00-755c-11eb-852d-63d8f98b60e9.png">
