### PR TITLE
Fix: Wrong way to remove duplicate feature ids

### DIFF
--- a/mealy/error_analysis_utils.py
+++ b/mealy/error_analysis_utils.py
@@ -54,8 +54,6 @@ def check_enough_data(df, min_len):
     :return:
     """
     if df.shape[0] < min_len:
-        raise ValueError('The original dataset is too small ({} rows) to have stable result, it needs to have at least {} rows'.format(df.shape[0], min_len))
-
-
-def rank_features_by_error_correlation(feature_importances):
-    return np.argsort(- feature_importances)
+        raise ValueError(
+            'The original dataset is too small ({} rows) to have stable result, it needs to have at least {} rows'.format(
+                df.shape[0], min_len))

--- a/mealy/error_visualizer.py
+++ b/mealy/error_visualizer.py
@@ -4,7 +4,6 @@ import graphviz as gv
 import pydotplus
 from sklearn.tree import export_graphviz
 import matplotlib.pyplot as plt
-from mealy.error_analysis_utils import rank_features_by_error_correlation
 from mealy.constants import ErrorAnalyzerConstants
 from mealy.error_analyzer import ErrorAnalyzer
 
@@ -230,14 +229,14 @@ class ErrorVisualizer(_BaseErrorVisualizer):
         """
 
         if self._error_analyzer.pipeline_preprocessor is None:
-            ranked_feature_ids = rank_features_by_error_correlation(self._error_clf.feature_importances_)
+            ranked_feature_ids = np.argsort(- self._error_clf.feature_importances_)
             if top_k_features != 0:
                 ranked_feature_ids = ranked_feature_ids[:top_k_features]
 
             x, y = self._error_analyzer._error_train_x[:, ranked_feature_ids], self._error_analyzer._error_train_y
             feature_names = self._error_analyzer.preprocessed_feature_names
         else:
-            ranked_transformed_feature_ids = rank_features_by_error_correlation(self._error_clf.feature_importances_)
+            ranked_transformed_feature_ids = np.argsort(- self._error_clf.feature_importances_)
             ranked_feature_ids, seen = [], set()
             max_nr_features = top_k_features if top_k_features > 0 else len(self._original_feature_names) + top_k_features
             for idx in ranked_transformed_feature_ids:

--- a/mealy/error_visualizer.py
+++ b/mealy/error_visualizer.py
@@ -91,7 +91,8 @@ class ErrorVisualizer(_BaseErrorVisualizer):
             self._numerical_feature_names = [f for f in self._original_feature_names if not self._error_analyzer.pipeline_preprocessor.is_categorical(name=f)]
 
     def plot_error_tree(self, size=None):
-        """Plot the graph of the decision tree.
+        """
+        Plot the graph of the decision tree.
 
         Args:
             size (tuple): size of the output plot.
@@ -192,39 +193,40 @@ class ErrorVisualizer(_BaseErrorVisualizer):
                                              show_global=True, show_class=True, rank_leaves_by="total_error_fraction",
                                              nr_bins=10, figsize=(15, 10)):
 
-        """Return plot of error node feature distribution and compare to global baseline.
+        """
+        Return feature distribution plots at the selected leaves.
 
-        The top-k features are sorted by importance in the ErrorAnalyzer.
-        The most important are more correlated with the errors. When no specific node is selected,
-        the leaves are ranked by an importance criterium and presented in relevance order.
+        The leaves for which the distributions are plotted are determined by the leaf_selector argument.
+        By default, no specific leaves are selected, and so the distributions are plotted for all the leaves.
+        The leaves are ranked following a criterion set via the argument rank_leaves_by.
+
+        The features are sorted by feature importance in the Error Tree. The more important a feature is, the more correlated with the errors it is.
+        The number of feature distributions to plot is set via top_k_features.
 
         Args:
-
             leaf_selector (None, int or array-like): the leaves whose information will be returned
-                * int: Only return information of the leaf with the corresponding id
-                * array-like: Only return information of the leaves corresponding to these ids
-                * None (default): Return information of all the leaves
+                * int: Only plot the feature distributions for the leaf matching the id
+                * array-like of int: Only plot the feature distributions for the leaves matching the ids
+                * None (default): Plot the feature distributions for all the leaves
 
             top_k_features (int): Number of features to plot per node.
-                * If a positive integer k is given, the distributions of the first k features (first in the sense of their importance) are displayed
-                * If a negative integer k is given, the distributions of all but the k last features (last in the sense of their importance) are displayed
-                * If k is 0, all the feature distributions are displayed
+                * If a positive integer k is given, the distributions of the first k features (first in the sense of their importance) are plotted
+                * If a negative integer k is given, the distributions of all but the k last features (last in the sense of their importance) are plotted
+                * If k is 0, all the feature distributions are plotted
 
-            show_global (bool): plot the feature distribution of samples in a node vs. samples in the whole data
-                (global baseline).
+            show_global (bool): Whether to plot the feature distributions for the whole data (global baseline) along with the ones for the leaf samples.
 
-            show_class (bool): show the proportion of Wrongly and Correctly predicted samples in the feature
-                distributions.
+            show_class (bool): Whether to show the proportion of Wrongly and Correctly predicted samples for each bin.
 
-            rank_leaves_by (str): ranking criterion for the leaves. Valid values are:
+            rank_leaves_by (str): Ranking criterion for the leaves. Valid values are:
                 * 'total_error_fraction': rank by the fraction of total error in the node
                 * 'purity': rank by the purity (ratio of wrongly predicted samples over the total number of node samples)
                 * 'class_difference': rank by the difference of number of wrongly and correctly predicted samples
                 in a node.
 
-            nr_bins (int): number of bins in the feature distribution plots.
+            nr_bins (int): Number of bins in the feature distribution plots. Defaults to 10.
 
-            figsize (tuple): size of the plots.
+            figsize (tuple of float): Tuple of size 2 for the size of the plots as (width, height) in inches. Defaults to (15, 10).
 
         """
 


### PR DESCRIPTION
This PR ensures we keep the order of the feature ids after removing the potential duplicates in `plot_feature_distributions_on_leaves`