### PR TITLE
Fix: do not plot leaf data if it is None

### DIFF
--- a/mealy/error_visualizer.py
+++ b/mealy/error_visualizer.py
@@ -40,16 +40,13 @@ class _BaseErrorVisualizer(object):
                 bottom = bar_heights
 
     @staticmethod
-    def _add_new_plot(figsize, bins, feature_name, leaf_id):
-        x_ticks = range(len(bins))
+    def _add_new_plot(figsize, bins, x_ticks, feature_name, leaf_id):
         plt.figure(figsize=figsize)
         plt.xticks(x_ticks)
         plt.gca().set_xticklabels(labels=bins)
         plt.xlabel('{}'.format(feature_name))
         plt.ylabel('Proportion of samples')
         plt.title('Distribution of {} in leaf {}'.format(feature_name, leaf_id))
-
-        return x_ticks
 
     @staticmethod
     def _plot_feature_distribution(x_ticks, feature_is_numerical, leaf_data, root_data=None):
@@ -298,7 +295,8 @@ class ErrorVisualizer(_BaseErrorVisualizer):
                     leaf_prediction = ErrorAnalyzerConstants.CORRECT_PREDICTION if proba_correct_leaf > proba_wrong_leaf else ErrorAnalyzerConstants.WRONG_PREDICTION
                     leaf_hist_data = {leaf_prediction: histogram_func(feature_column[leaf_sample_ids])}
 
-                x_ticks = _BaseErrorVisualizer._add_new_plot(figsize, bins, feature_name, leaf)
+                x_ticks = range(len(bins))
+                _BaseErrorVisualizer._add_new_plot(figsize, bins, x_ticks, feature_name, leaf)
                 _BaseErrorVisualizer._plot_feature_distribution(x_ticks, feature_is_numerical, leaf_hist_data, root_hist_data)
                 break
 

--- a/mealy/error_visualizer.py
+++ b/mealy/error_visualizer.py
@@ -298,6 +298,5 @@ class ErrorVisualizer(_BaseErrorVisualizer):
                 x_ticks = range(len(bins))
                 _BaseErrorVisualizer._add_new_plot(figsize, bins, x_ticks, feature_name, leaf)
                 _BaseErrorVisualizer._plot_feature_distribution(x_ticks, feature_is_numerical, leaf_hist_data, root_hist_data)
-                break
 
         plt.show()

--- a/mealy/error_visualizer.py
+++ b/mealy/error_visualizer.py
@@ -59,9 +59,10 @@ class _BaseErrorVisualizer(object):
             if feature_is_numerical:
                 x = x_ticks[1:]
             _BaseErrorVisualizer._plot_histograms(root_data, label="global data", x=x, hatch="///", width=-width)
-        if feature_is_numerical:
-            x = x_ticks[:-1]
-        _BaseErrorVisualizer._plot_histograms(leaf_data, label="leaf data", x=x, width=width)
+        if leaf_data is not None:
+            if feature_is_numerical:
+                x = x_ticks[:-1]
+            _BaseErrorVisualizer._plot_histograms(leaf_data, label="leaf data", x=x, width=width)
 
         plt.legend()
         plt.pause(0.05)
@@ -280,6 +281,8 @@ class ErrorVisualizer(_BaseErrorVisualizer):
                     else:
                         root_prediction = ErrorAnalyzerConstants.CORRECT_PREDICTION if nr_wrong[0] < self._error_tree.n_total_errors / 2 else ErrorAnalyzerConstants.WRONG_PREDICTION
                         root_hist_data = {root_prediction: histogram_func(feature_column)}
+                else:
+                    root_hist_data = None
 
                 if show_class:
                     hist_wrong = histogram_func(feature_column[leaf_sample_ids & total_error_fraction_sample_ids])
@@ -296,7 +299,7 @@ class ErrorVisualizer(_BaseErrorVisualizer):
                     leaf_hist_data = {leaf_prediction: histogram_func(feature_column[leaf_sample_ids])}
 
                 x_ticks = _BaseErrorVisualizer._add_new_plot(figsize, bins, feature_name, leaf)
-                _BaseErrorVisualizer._plot_feature_distribution(x_ticks, feature_is_numerical, leaf_hist_data, root_hist_data if show_global else None)
+                _BaseErrorVisualizer._plot_feature_distribution(x_ticks, feature_is_numerical, leaf_hist_data, root_hist_data)
                 break
 
         plt.show()


### PR DESCRIPTION
This PR:
- prevents call to `_BaseErrorVisualizer._plot_histograms` from `_BaseErrorVisualizer#_plot_feature_distribution` if leaf data is None 5f7482e
   - [ ] Open question: I might be mistaken but I think `bins` can never be of size 0 in `ErrorVisualizer#plot_feature_distributions_on_leaves`, this is for ths inherting classes of `_BaseErrorVisualizer` only. If I am mistaken however, minor changes will need to be made
- does some minor cleaning 5f7482e
- removes a buggy `break` 5f7482e