### PR TITLE
Fix: Ensure `PipelineProcessor` works if `ColumnTransformer` uses remainder='passthrough'

### DIFF
--- a/mealy/constants.py
+++ b/mealy/constants.py
@@ -36,6 +36,7 @@ class ErrorAnalyzerConstants(object):
                                                    Binarizer, Normalizer, MinMaxScaler, RobustScaler, SimpleImputer,
                                                    OrdinalEncoder)
     STEPS_THAT_CHANGE_OUTPUT_DIMENSION_WITH_OUTPUT_FEATURE_NAMES = (OneHotEncoder,)
+    SUPPORTED_STEPS = STEPS_THAT_DOES_NOT_CHANGE_OUTPUT_DIMENSION + STEPS_THAT_CHANGE_OUTPUT_DIMENSION_WITH_OUTPUT_FEATURE_NAMES
     GRAPH_MAX_EDGE_WIDTH = 10
     GRAPH_MIN_LOCAL_ERROR_OPAQUE = 0.5
     

--- a/mealy/error_analysis_utils.py
+++ b/mealy/error_analysis_utils.py
@@ -34,7 +34,7 @@ def generate_preprocessing_steps(transformer, invert_order=False):
         if step == 'drop':
             # Skip the drop step of ColumnTransformer
             continue
-        if not isinstance(step, ErrorAnalyzerConstants.SUPPORTED_STEPS):
+        if step != 'passthrough' and not isinstance(step, ErrorAnalyzerConstants.SUPPORTED_STEPS):
             # Check all the preprocessing steps are supported by mealy
             unsupported_class = step.__class__
             raise TypeError('Mealy package does not support {}. '.format(unsupported_class) +
@@ -43,6 +43,13 @@ def generate_preprocessing_steps(transformer, invert_order=False):
                         'generated features, or that it does not provide an ' +
                         'inverse_tranform method.')
         yield step
+
+def invert_transform_via_identity(step):
+    if isinstance(step, ErrorAnalyzerConstants.STEPS_THAT_CAN_BE_INVERSED_WITH_IDENTICAL_FUNCTION):
+        return True
+    if step == 'passthrough' or step is None:
+        return True
+    return False
 
 def check_lists_having_same_elements(list_A, list_B):
     return set(list_A) == set(list_B)

--- a/mealy/preprocessing.py
+++ b/mealy/preprocessing.py
@@ -5,7 +5,7 @@ import pandas as pd
 from scipy.sparse import issparse
 from collections import defaultdict
 import logging
-from mealy.error_analysis_utils import check_lists_having_same_elements, generate_preprocessing_steps
+from mealy.error_analysis_utils import check_lists_having_same_elements, generate_preprocessing_steps, invert_transform_via_identity
 from mealy.constants import ErrorAnalyzerConstants
 
 logger = logging.getLogger(__name__)
@@ -169,10 +169,10 @@ class PipelinePreprocessor(FeatureNameTransformer):
     def _inverse_single_step(single_step, step_output, transformer_feature_names):
         inverse_transform_function_available = getattr(single_step, "inverse_transform", None)
         if inverse_transform_function_available:
-            logger.info("Reversing step {} using inverse_transform() function on column(s): {}".format(single_step, ', '.join(transformer_feature_names)))
+            logger.info("Reversing step using inverse_transform() method on column(s): {}".format(single_step, ', '.join(transformer_feature_names)))
             return single_step.inverse_transform(step_output)
-        if isinstance(single_step, ErrorAnalyzerConstants.STEPS_THAT_CAN_BE_INVERSED_WITH_IDENTICAL_FUNCTION):
-            logger.info("Reversing step {} using identity transformation on column(s): {}".format(single_step, ', '.join(transformer_feature_names)))
+        if invert_transform_via_identity(single_step):
+            logger.info("Reversing step using identity transformation on column(s): {}".format(single_step, ', '.join(transformer_feature_names)))
             return step_output
         raise TypeError('The package does not support {} because it does not provide inverse_transform function.'.format(single_step))
 

--- a/mealy/preprocessing.py
+++ b/mealy/preprocessing.py
@@ -168,12 +168,12 @@ class PipelinePreprocessor(FeatureNameTransformer):
     @staticmethod
     def _inverse_single_step(single_step, step_output, transformer_feature_names):
         inverse_transform_function_available = getattr(single_step, "inverse_transform", None)
-        if inverse_transform_function_available:
-            logger.info("Reversing step using inverse_transform() method on column(s): {}".format(single_step, ', '.join(transformer_feature_names)))
-            return single_step.inverse_transform(step_output)
         if invert_transform_via_identity(single_step):
             logger.info("Reversing step using identity transformation on column(s): {}".format(single_step, ', '.join(transformer_feature_names)))
             return step_output
+        if inverse_transform_function_available:
+            logger.info("Reversing step using inverse_transform() method on column(s): {}".format(single_step, ', '.join(transformer_feature_names)))
+            return single_step.inverse_transform(step_output)
         raise TypeError('The package does not support {} because it does not provide inverse_transform function.'.format(single_step))
 
     def inverse_transform(self, preprocessed_x):

--- a/mealy/preprocessing.py
+++ b/mealy/preprocessing.py
@@ -73,7 +73,6 @@ class PipelinePreprocessor(FeatureNameTransformer):
         self.ct_preprocessor = ct_preprocessor
         self.original2preprocessed = {}
         self.preprocessed2original = {}
-        self.len_preproc = 0
 
         logger.info('Retrieving the list of features used in the pipeline')
         original_features_from_ct, self.categorical_features = get_feature_list_from_column_transformer(self.ct_preprocessor)
@@ -86,63 +85,50 @@ class PipelinePreprocessor(FeatureNameTransformer):
         super(PipelinePreprocessor, self).__init__(original_features=original_features, preprocessed_features=[])
 
         logger.info('Generating the feature id mapping dict')
-        self._create_feature_mapping(ct_preprocessor)
+        self._create_feature_mapping()
 
     def _create_feature_mapping(self):
         """
         Update the dicts of input <-> output feature id mapping: self.original2preprocessed and self.preprocessed2original
         """
-        for i, (transformer_name, transformer, transformer_feature_names) in enumerate(self.ct_preprocessor.transformers_):
-            orig_feats_ids = np.where(np.in1d(self.original_feature_names, transformer_feature_names))[0]
-            if isinstance(transformer, Pipeline):
-                # The assumption here is that for each pipeline there is at most one step that change feature dimension
-                # For now, the only possible function is OneHotEncoder
+        for transformer_name, transformer, transformer_feature_names in self.ct_preprocessor.transformers_:
+            orig_feat_ids = np.where(np.in1d(self.original_feature_names, transformer_feature_names))[0]
+            transformers = transformer.steps if isinstance(transformer, Pipeline)\
+                else [(transformer_name, transformer)]
 
-                # We take by default the first step in the pipeline
-                single_tr = transformer.steps[0][1]
-                # Check if there is a step than changes the output dimension, if that's the case single_tr will be it
-                for (step_name, step) in transformer.steps:
-                    if isinstance(step, ErrorAnalyzerConstants.STEPS_THAT_CHANGE_OUTPUT_DIMENSION_WITH_OUTPUT_FEATURE_NAMES):
-                        single_tr = step
-                        break
-                if isinstance(single_tr, ErrorAnalyzerConstants.STEPS_THAT_DOES_NOT_CHANGE_OUTPUT_DIMENSION):
-                    self._update_feature_mapping_dict_using_input_names(transformer_feature_names, orig_feats_ids)
-                elif isinstance(single_tr, ErrorAnalyzerConstants.STEPS_THAT_CHANGE_OUTPUT_DIMENSION_WITH_OUTPUT_FEATURE_NAMES):
-                    self._update_feature_mapping_dict_using_output_names(single_tr, transformer_feature_names, orig_feats_ids)
-                else:
-                    raise TypeError('The package does not support {}, probably because it changes output dimension '
-                                     'but does not provide get_feature_names function to keep track of new features '
-                                     'generated.'.format(single_tr))
+            output_dimension_is_changed = False
+            for name, step in transformers:
+                if name == 'remainder' and step == 'drop':
+                    # Skip the default drop step of ColumnTransformer
+                    continue
+                if isinstance(step, ErrorAnalyzerConstants.STEPS_THAT_CHANGE_OUTPUT_DIMENSION_WITH_OUTPUT_FEATURE_NAMES):
+                    # It is assumed that for each pipeline, at most one step changes the feature's dimension
+                    # For now, it can only be a OneHotEncoder step
+                    self._update_feature_mapping_dict_using_output_names(step,
+                                                                         transformer_feature_names,
+                                                                         orig_feat_ids)
+                    output_dimension_is_changed = True
+                    break
+            if not output_dimension_is_changed:
+                self._update_feature_mapping_dict_using_input_names(transformer_feature_names, orig_feat_ids)
 
-            elif isinstance(transformer, ErrorAnalyzerConstants.STEPS_THAT_DOES_NOT_CHANGE_OUTPUT_DIMENSION):
-                self._update_feature_mapping_dict_using_input_names(transformer_feature_names, orig_feats_ids)
-            elif isinstance(transformer, ErrorAnalyzerConstants.STEPS_THAT_CHANGE_OUTPUT_DIMENSION_WITH_OUTPUT_FEATURE_NAMES):
-                self._update_feature_mapping_dict_using_output_names(transformer, transformer_feature_names, orig_feats_ids)
-            elif transformer_name == 'remainder' and transformer == 'drop':
-                # skip the default drop step of ColumnTransformer
-                continue
-            else:
-                raise TypeError('The package does not support {}, probably because it changes output dimension but '
-                                 'does not provide get_feature_names function to keep track of new '
-                                 'features generated.'.format(transformer))
-
-    def _update_feature_mapping_dict_using_input_names(self, transformer_feature_names, orig_feats_ids):
+    def _update_feature_mapping_dict_using_input_names(self, transformer_feature_names, original_feature_ids):
         self.preprocessed_feature_names.extend(transformer_feature_names)
-        self.original2preprocessed.update({in_i: self.len_preproc + i for i, in_i in enumerate(orig_feats_ids)})
-        self.preprocessed2original.update({self.len_preproc + i: in_i for i, in_i in enumerate(orig_feats_ids)})
-        self.len_preproc += len(transformer_feature_names)
+        for original_feat_id in original_feature_ids:
+            idx = len(self.preprocessed2original)
+            self.original2preprocessed[original_feat_id] = [idx]
+            self.preprocessed2original[idx] = original_feat_id
 
     def _update_feature_mapping_dict_using_output_names(self, single_transformer, transformer_feature_names, original_feature_ids):
-        """
-        For now, this functions only applies for OnehotEncoder
-        """
         out_feature_names = list(single_transformer.get_feature_names(input_features=transformer_feature_names))
         self.preprocessed_feature_names.extend(out_feature_names)
         for orig_id, orig_name in zip(original_feature_ids, transformer_feature_names):
-            part_out_feature_names = [i for i, name in enumerate(out_feature_names) if orig_name + '_' in name]
-            self.original2preprocessed.update({orig_id: [self.len_preproc + i for i in range(len(part_out_feature_names))]})
-            self.preprocessed2original.update({self.len_preproc + i: orig_id for i in range(len(part_out_feature_names))})
-            self.len_preproc += len(part_out_feature_names)
+            part_out_feature_names = [name for name in out_feature_names if orig_name + '_' in name]
+            self.original2preprocessed[orig_id] = []
+            offset = len(self.preprocessed2original)
+            for i in range(len(part_out_feature_names)):
+                self.original2preprocessed[orig_id].append(offset + i)
+                self.preprocessed2original[offset + i] = orig_id
 
     def _transform_feature_id(self, index):
         """
@@ -169,21 +155,17 @@ class PipelinePreprocessor(FeatureNameTransformer):
         original_feature_ids = np.where(np.in1d(original_features, transformer_feature_names))[0]
         preprocessed_feature_ids = []
         for i in original_feature_ids:
-            out_ids = self._transform_feature_id(i)
-            if isinstance(out_ids, int):
-                preprocessed_feature_ids.append(out_ids)
-            else:  # list of ids
-                preprocessed_feature_ids.extend(out_ids)
+            preprocessed_feature_ids += self._transform_feature_id(i)
         return original_feature_ids, preprocessed_feature_ids
 
     @staticmethod
     def _inverse_single_step(single_step, step_output, transformer_feature_names):
         inverse_transform_function_available = getattr(single_step, "inverse_transform", None)
         if inverse_transform_function_available:
-            logger.info("Reversing step {} using inverse_transform() function on column(s): {}".format(single_step, ', '.join([f for f in transformer_feature_names])))
+            logger.info("Reversing step {} using inverse_transform() function on column(s): {}".format(single_step, ', '.join(transformer_feature_names)))
             return single_step.inverse_transform(step_output)
         if isinstance(single_step, ErrorAnalyzerConstants.STEPS_THAT_CAN_BE_INVERSED_WITH_IDENTICAL_FUNCTION):
-            logger.info("Reversing step {} using identity transformation on column(s): {}".format(single_step, ', '.join([f for f in transformer_feature_names])))
+            logger.info("Reversing step {} using identity transformation on column(s): {}".format(single_step, ', '.join(transformer_feature_names)))
             return step_output
         raise TypeError('The package does not support {} because it does not provide inverse_transform function.'.format(single_step))
 
@@ -197,8 +179,8 @@ class PipelinePreprocessor(FeatureNameTransformer):
             numpy.ndarray: feature values without preprocessing.
 
         """
-        original_features = self.get_original_feature_names()
-        undo_prep_test_x = np.zeros((preprocessed_x.shape[0], len(original_features)), dtype='O')
+        nr_original_features = len(self.get_original_feature_names())
+        undo_prep_test_x = np.zeros((preprocessed_x.shape[0], nr_original_features), dtype='O')
 
         for (transformer_name, transformer, transformer_feature_names) in self.ct_preprocessor.transformers_:
             if transformer_name == 'remainder' and transformer == 'drop':
@@ -210,15 +192,13 @@ class PipelinePreprocessor(FeatureNameTransformer):
             if issparse(output_of_transformer) and any_numeric:
                 output_of_transformer = output_of_transformer.todense()
 
-            input_of_transformer = None
-            if isinstance(transformer, Pipeline):
-                for _, step in reversed(transformer.steps):
-                    input_of_transformer = PipelinePreprocessor._inverse_single_step(step, output_of_transformer, transformer_feature_names)
-                    output_of_transformer = input_of_transformer
-                undo_prep_test_x[:, original_feature_ids] = input_of_transformer
-            else:
-                input_of_transformer = PipelinePreprocessor._inverse_single_step(transformer, output_of_transformer, transformer_feature_names)
-                undo_prep_test_x[:, original_feature_ids] = input_of_transformer
+            transformers = reversed(transformer.steps) if isinstance(transformer, Pipeline) else [(transformer_name, transformer)]
+            for name, step in transformers:
+                if name == 'remainder' and step == 'drop':
+                    continue
+                input_of_transformer = PipelinePreprocessor._inverse_single_step(step, output_of_transformer, transformer_feature_names)
+                output_of_transformer = input_of_transformer
+            undo_prep_test_x[:, original_feature_ids] = input_of_transformer
 
         return undo_prep_test_x
 

--- a/mealy/preprocessing.py
+++ b/mealy/preprocessing.py
@@ -187,12 +187,12 @@ class PipelinePreprocessor(FeatureNameTransformer):
         """
         nr_original_features = len(self.get_original_feature_names())
         undo_prep_test_x = np.zeros((preprocessed_x.shape[0], nr_original_features), dtype='O')
-        any_numeric = np.any(np.vectorize(lambda x: not self.is_categorical(x)))
+        any_cat = np.vectorize(lambda x: self.is_categorical(x))
 
         for _, transformer, feature_names in self.ct_preprocessor.transformers_:
             original_feature_ids, preprocessed_feature_ids = self._get_feature_ids_related_to_transformer(feature_names)
             transformer_output = preprocessed_x[:, preprocessed_feature_ids]
-            if issparse(transformer_output) and any_numeric(transformer_output):
+            if issparse(transformer_output) and not np.any(any_cat(original_feature_ids)):
                 transformer_output = transformer_output.todense()
 
             # TODO: could be simplified as sklearn.Pipeline implements inverse_transform

--- a/mealy/preprocessing.py
+++ b/mealy/preprocessing.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from sklearn.pipeline import Pipeline
 import numpy as np
 import pandas as pd
 from scipy.sparse import issparse

--- a/mealy/tests/test_error_tree.py
+++ b/mealy/tests/test_error_tree.py
@@ -1,17 +1,18 @@
 import numpy as np
-import unittest
+from unittest import TestCase
+from unittest.mock import Mock
 
 from sklearn.exceptions import NotFittedError
 from mealy import ErrorTree, ErrorAnalyzerConstants
 
 
-class TestErrorTree(unittest.TestCase):
+class TestErrorTree(TestCase):
     def test_empty_tree(self):
         with self.assertRaises(NotFittedError, msg="You should fit the ErrorAnalyzer first"):
             ErrorTree(None)
 
     def test_small_tree(self):
-        clf = unittest.mock.Mock()
+        clf = Mock()
         clf.tree_.node_count = 1
         with self.assertLogs("mealy.error_tree", level="WARNING") as caplog:
             error_tree = ErrorTree(clf)
@@ -21,7 +22,7 @@ class TestErrorTree(unittest.TestCase):
             ])
 
     def test_tree(self):
-        tree_ = unittest.mock.Mock(value=np.array([
+        tree_ = Mock(value=np.array([
             [[42, 69]],
             [[2, 9]],
             [[40, 58]],
@@ -35,7 +36,7 @@ class TestErrorTree(unittest.TestCase):
             [[27, 18]]
             ]), feature=np.array([1, 2, -2, -2, 0, -2, -2, 0, 1]))
 
-        clf = unittest.mock.Mock(classes_=np.array([ErrorAnalyzerConstants.CORRECT_PREDICTION,
+        clf = Mock(classes_=np.array([ErrorAnalyzerConstants.CORRECT_PREDICTION,
             ErrorAnalyzerConstants.WRONG_PREDICTION]), tree_=tree_)
 
         error_tree = ErrorTree(clf)

--- a/mealy/tests/test_preprocessing.py
+++ b/mealy/tests/test_preprocessing.py
@@ -70,11 +70,11 @@ class TestDummyPipeline(TestFeatureTransformer):
         self.assertEqual(self.pipe.inverse_transform_feature_id(1), 1)
 
 
-class TestPreprocessingPipelineWithPipeline(TestFeatureTransformer):
+class TestPreprocessingPipeline(TestFeatureTransformer):
     @unittest.mock.patch("mealy.preprocessing.PipelinePreprocessor._get_feature_list_from_column_transformer", return_value=["num_1", "num_2", "cat_1", "cat_2"])
     @unittest.mock.patch("mealy.preprocessing.PipelinePreprocessor._create_feature_mapping", return_value=None)
     def setUp(self, patched_create_mapping, patched_feature_list):
-        super(TestPreprocessingPipelineWithPipeline, self).setUp()
+        super(TestPreprocessingPipeline, self).setUp()
         col_transformer = unittest.mock.Mock(spec=ColumnTransformer)
         self.pipe = PipelinePreprocessor(col_transformer)
 

--- a/mealy/tests/test_preprocessing.py
+++ b/mealy/tests/test_preprocessing.py
@@ -2,7 +2,8 @@ import numpy as np
 import pandas as pd
 from scipy.sparse import csr_matrix, issparse
 import random
-import unittest
+from unittest import TestCase
+from unittest.mock import patch, Mock
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import StandardScaler, OneHotEncoder
 from sklearn.impute import SimpleImputer
@@ -15,7 +16,7 @@ np.random.seed(default_seed)
 random.seed(default_seed)
 
 
-class TestFeatureTransformer(unittest.TestCase):
+class TestFeatureTransformer(TestCase):
     def setUp(self):
         self.feature_list = ["num_1", "num_2", "cat_1", "cat_2"]
         self.x = np.array([[1, 2, 3], [2, 4, 6], [3, 6, 9]])
@@ -71,20 +72,20 @@ class TestDummyPipeline(TestFeatureTransformer):
 
 
 class TestPreprocessingPipeline(TestFeatureTransformer):
-    @unittest.mock.patch("mealy.preprocessing.PipelinePreprocessor._get_feature_list_from_column_transformer", return_value=["num_1", "num_2", "cat_1", "cat_2"])
-    @unittest.mock.patch("mealy.preprocessing.PipelinePreprocessor._create_feature_mapping", return_value=None)
-    def setUp(self, patched_create_mapping, patched_feature_list):
+    def setUp(self):
         super(TestPreprocessingPipeline, self).setUp()
-        col_transformer = unittest.mock.Mock(spec=ColumnTransformer)
-        self.pipe = PipelinePreprocessor(col_transformer)
+        col_transformer = Mock(spec=ColumnTransformer)
+        with patch("mealy.preprocessing.PipelinePreprocessor._get_feature_list_from_column_transformer", return_value=["num_1", "num_2", "cat_1", "cat_2"]),\
+            patch("mealy.preprocessing.PipelinePreprocessor._create_feature_mapping", return_value=None):
+            self.pipe = PipelinePreprocessor(col_transformer)
 
-    @unittest.mock.patch("mealy.preprocessing.PipelinePreprocessor._update_feature_mapping_dict_using_input_names", return_value=None)
-    @unittest.mock.patch("mealy.preprocessing.PipelinePreprocessor._update_feature_mapping_dict_using_output_names", return_value=None)
-    @unittest.mock.patch("mealy.preprocessing.generate_preprocessing_steps", side_effect=lambda transformer: transformer)
+    @patch("mealy.preprocessing.PipelinePreprocessor._update_feature_mapping_dict_using_input_names", return_value=None)
+    @patch("mealy.preprocessing.PipelinePreprocessor._update_feature_mapping_dict_using_output_names", return_value=None)
+    @patch("mealy.preprocessing.generate_preprocessing_steps", side_effect=lambda transformer: transformer)
     def test_create_feature_mapping_output_dim_change(self, _, mocked_o, mocked_i):
-        ohe = unittest.mock.Mock(spec=OneHotEncoder)
+        ohe = Mock(spec=OneHotEncoder)
         steps = [
-            unittest.mock.Mock(spec=StandardScaler),
+            Mock(spec=StandardScaler),
             "drop",
             "passthrough",
             ohe
@@ -98,15 +99,15 @@ class TestPreprocessingPipeline(TestFeatureTransformer):
         self.assertEqual(mocked_o.call_count, 1)
         self.assertEqual(mocked_i.call_count, 0)
 
-    @unittest.mock.patch("mealy.preprocessing.PipelinePreprocessor._update_feature_mapping_dict_using_input_names", return_value=None)
-    @unittest.mock.patch("mealy.preprocessing.PipelinePreprocessor._update_feature_mapping_dict_using_output_names", return_value=None)
-    @unittest.mock.patch("mealy.preprocessing.generate_preprocessing_steps", side_effect=lambda transformer: transformer)
+    @patch("mealy.preprocessing.PipelinePreprocessor._update_feature_mapping_dict_using_input_names", return_value=None)
+    @patch("mealy.preprocessing.PipelinePreprocessor._update_feature_mapping_dict_using_output_names", return_value=None)
+    @patch("mealy.preprocessing.generate_preprocessing_steps", side_effect=lambda transformer: transformer)
     def test_create_feature_mapping_no_change_in_output_dim(self, _, mocked_o, mocked_i):
         steps = [
-            unittest.mock.Mock(spec=StandardScaler),
+            Mock(spec=StandardScaler),
             "drop",
             "passthrough",
-            unittest.mock.Mock(spec=SimpleImputer)
+            Mock(spec=SimpleImputer)
         ]
         self.pipe.ct_preprocessor.transformers_ = [("does_not_matter", steps, self.feature_list)]
         self.pipe._create_feature_mapping()
@@ -123,7 +124,7 @@ class TestPreprocessingPipeline(TestFeatureTransformer):
         self.assertDictEqual(self.pipe.preprocessed2original, {0: 0, 1: 4})
 
     def test_update_feature_mapping_dict_using_output_names(self):
-        single_tr = unittest.mock.Mock()
+        single_tr = Mock()
         single_tr.get_feature_names.return_value = ["very_transformed_name_1_0", "even_more_transformed_name"]
         self.pipe._update_feature_mapping_dict_using_output_names(single_tr, ["transformed_name_1", "transformed_name_2"], [0, 4])
         self.assertListEqual(self.pipe.preprocessed_feature_names, ["very_transformed_name_1_0", "even_more_transformed_name"])
@@ -142,11 +143,11 @@ class TestPreprocessingPipeline(TestFeatureTransformer):
         with self.assertRaises(ValueError, msg="Either the input index or its name should be specified."):
             self.pipe.is_categorical()
 
-    @unittest.mock.patch("mealy.preprocessing.PipelinePreprocessor.inverse_transform_feature_id", side_effect=lambda idx: idx)
-    @unittest.mock.patch("mealy.preprocessing.PipelinePreprocessor.inverse_transform", side_effect=lambda a: a+1)
+    @patch("mealy.preprocessing.PipelinePreprocessor.inverse_transform_feature_id", side_effect=lambda idx: idx)
+    @patch("mealy.preprocessing.PipelinePreprocessor.inverse_transform", side_effect=lambda a: a+1)
     def test_inverse_thresholds(self, mocked_inverse_transform, mocked_inverse_transform_feature_id):
         nr_cols = 6
-        tree = unittest.mock.Mock(feature=np.array([0,-2,1,3,-2,-2,0]), threshold=np.array([1, -2, 42,6,-2,-2,12]))
+        tree = Mock(feature=np.array([0,-2,1,3,-2,-2,0]), threshold=np.array([1, -2, 42,6,-2,-2,12]))
         thresholds = self.pipe.inverse_thresholds(tree, nr_cols)
         a = mocked_inverse_transform.call_args[0][0]
         self.assertTrue(mocked_inverse_transform.call_count == 1)
@@ -184,20 +185,20 @@ class TestPreprocessingPipeline(TestFeatureTransformer):
         self.assertListEqual(self.pipe.get_top_ranked_feature_ids(importance, -1), [3, 1])
         self.assertListEqual(self.pipe.get_top_ranked_feature_ids(importance, 1), [3])
 
-    @unittest.mock.patch("mealy.preprocessing.generate_preprocessing_steps", side_effect=lambda transformer: transformer)
+    @patch("mealy.preprocessing.generate_preprocessing_steps", side_effect=lambda transformer: transformer)
     def test_get_feature_list_from_column_transformer(self, _):
         steps = [
             "drop",
             "passthrough",
-            unittest.mock.Mock(spec=StandardScaler),
-            unittest.mock.Mock(spec=OneHotEncoder)
+            Mock(spec=StandardScaler),
+            Mock(spec=OneHotEncoder)
         ]
 
         other_steps = [
             "drop",
             "passthrough",
-            unittest.mock.Mock(spec=StandardScaler),
-            unittest.mock.Mock(spec=SimpleImputer)
+            Mock(spec=StandardScaler),
+            Mock(spec=SimpleImputer)
         ]
 
         self.pipe.ct_preprocessor.transformers_ = [


### PR DESCRIPTION
## In this PR
- Slight refactoring of `PipelineProcessor` (9ce8f7a and 54663a5)
- 🔴 Fix: ensure `PipelineProcessor` works if `ColumnTransformer` uses `remainder='passthrough'`  (702c3e2)
  - Using `None` for the step value is also accepted
- 🔴 Fix: pass the output column to `any_numeric` method (e66c58c)
   - Actually was still broken, additional fix here: fe89250
- Check first that the step should use identity to invert its processing, instead of checking for `inverse_transform` method (29138e4)
- Update the unit tests (3149034 + renaming the class in 7f5201d)

## Not handled in this PR, but to be taken into account
- To be fixed: Categorical features that are not preprocessed but not dropped neither (using `remainder:'passthrough'`) will **not** be detected as categorical (--> Seems like a pretty edgy case though, but also an easy fix: we can add a `categorical_features` argument to the constructor)

Improvements: 
- `Pipeline` implements `inverse_transform`, we could (should?) use it **directly** instead of inverting each step
- Probably not as urgent, we might want to leverage `SimpleImputer#inverse_transform` instead of using identity, and so only use identity for inverse tranform when a column is not preprocessed nor dropped (aka, `passthrough` case)