### PR TITLE
Fix the error proportion in regression models

### DIFF
--- a/mealy/error_analyzer.py
+++ b/mealy/error_analyzer.py
@@ -178,8 +178,9 @@ class ErrorAnalyzer(BaseEstimator):
 
         leaves_summary = []
         for leaf_id in leaf_nodes:
-            n_errors = int(self.error_tree.estimator_.tree_.value[leaf_id, 0, self.error_tree.error_class_idx])
             n_samples = self.error_tree.estimator_.tree_.n_node_samples[leaf_id]
+            class_proportion = self.error_tree.estimator_.tree_.value[leaf_id, 0, self.error_tree.error_class_idx]
+            n_errors = class_proportion * n_samples if is_regressor(self._primary_model) else int(class_proportion)
             local_error = n_errors / n_samples
             total_error_fraction = n_errors / self.error_tree.n_total_errors
             n_corrects = n_samples - n_errors


### PR DESCRIPTION
**Problem**

The method `self.error_tree.estimator_.tree_.value` does not correctly return the error count when the model analyzed is a regression model. Instead, it provides normalized class proportions, which leads to incorrect calculations of n_errors for regression tasks in the `get_error_leaf_summary` function.

**Reproduction of error**

```
import numpy as np
import pandas as pd
from sklearn.datasets import fetch_california_housing
from sklearn.tree import DecisionTreeRegressor
from sklearn.model_selection import train_test_split
from mealy.error_analyzer import ErrorAnalyzer

# Fetch California Housing Dataset
housing = fetch_california_housing()
X = pd.DataFrame(housing.data, columns=housing.feature_names)
y_true = housing.target

# Train-Test Split
X_train, X_test, y_train, y_test = train_test_split(X, y_true, test_size=0.3, random_state=42)

# Fit Primary Model
primary_model = DecisionTreeRegressor(max_depth=2, random_state=42)
primary_model.fit(X_train, y_train)

# Initialize ErrorAnalyzer
error_analyzer = ErrorAnalyzer(primary_model, feature_names=housing.feature_names, param_grid={"max_depth": [2]}, random_state=42)
error_analyzer.epsilon = 0.5
error_analyzer.fit(X_test, y_test)

# Validate Issue: Inspect a Node
leaf_id = 2
n_errors = error_analyzer.get_error_leaf_summary(leaf_id)[0]["n_errors"]

# Manual Verification
y_pred = primary_model.predict(X_test)
node_samples = error_analyzer.error_tree.estimator_.apply(X_test) == leaf_id
node_errors = (np.abs(y_test[node_samples] - y_pred[node_samples]) > error_analyzer.epsilon).sum()

# The assertion highlights the discrepancy
assert n_errors != node_errors  # n_errors from the library is incorrect for regression tasks
```

**Root Cause**

For regression tasks, self.error_tree.estimator_.tree_.value returns proportions, not absolute counts, for the class predictions. This behavior is appropriate for classification tasks but not for regression, leading to incorrect calculations of n_errors.

**Solution**

The fix involves correctly handling regression-specific logic by:

1. Multiplying the normalized proportion (`self.error_tree.estimator_.tree_.value`) by the total number of samples in the node (`self.error_tree.estimator_.tree_.n_node_samples`).
2. Ensuring consistent behavior for both regression and classification models.